### PR TITLE
Improve class constructors

### DIFF
--- a/nb/parallel.ipynb
+++ b/nb/parallel.ipynb
@@ -25,9 +25,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import sys\n",
-    "sys.path.append('../src')\n",
-    "\n",
     "from dffc.correction import DynamicFlatFieldCorrectionCython as DynamicFlatFieldCorrection\n",
     "from dffc.offline import FlatFieldCorrectionFileProcessor"
    ]
@@ -49,9 +46,11 @@
     "downsample_factors = (2, 4)\n",
     "\n",
     "fn = f\"pca_cam{camno}_d{runno_dark}_f{runno_flat}_r{n_components}.h5\"\n",
-    "cam_source = f\"SPB_EHD_HPVX2_{camno}/CAM/CAMERA:daqOutput\"\n",
+    "karabo_id = f\"SPB_EHD_HPVX2_{camno}\"\n",
+    "cam_source = f\"{karabo_id}/CAM/CAMERA:daqOutput\"\n",
+    "image_key = \"data.image.pixels\"\n",
     "\n",
-    "dffc = DynamicFlatFieldCorrection.from_file(fn, cam_source, downsample_factors)"
+    "dffc = DynamicFlatFieldCorrection.from_file(fn, karabo_id, downsample_factors)"
    ]
   },
   {
@@ -80,7 +79,7 @@
    "source": [
     "tm0 = time.monotonic()\n",
     "\n",
-    "proc = FlatFieldCorrectionFileProcessor(dffc, 32)\n",
+    "proc = FlatFieldCorrectionFileProcessor(dffc, 32, cam_source, image_key)\n",
     "\n",
     "proc.start_workers()\n",
     "proc.run(run)\n",
@@ -97,14 +96,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def process_run(dffc, run):\n",
+    "def process_run(dffc, run, source, image_key=\"data.image.pixels\"):\n",
     "    results = []\n",
     "    weights = []\n",
     "    warnflag = []\n",
     "\n",
-    "    cam_data = run.select([(dffc.source, \"data.image.pixels\")])\n",
+    "    cam_data = run.select([(source, image_key)])\n",
     "    for tid, data in cam_data.trains():\n",
-    "        images = data[dffc.source].get('data.image.pixels')\n",
+    "        images = data[source].get(image_key)\n",
     "        if images is None:\n",
     "            continue\n",
     "        \n",
@@ -118,7 +117,7 @@
     "tm0 = time.monotonic()\n",
     "\n",
     "#images = run[cam_source, 'data.image.pixels'].ndarray()\n",
-    "r, w, warnflag = process_run(dffc, run)\n",
+    "r, w, warnflag = process_run(dffc, run, cam_source)\n",
     "\n",
     "tm1 = time.monotonic()\n",
     "print(f\"Time: {tm1-tm0:.2f} s\")"
@@ -220,7 +219,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,

--- a/src/dffc/correction.py
+++ b/src/dffc/correction.py
@@ -10,14 +10,20 @@ from .totalvar_numba import totalvar_numba, grad_totalvar_numba
 
 class DynamicFlatFieldCorrectionBase:
 
-    def __init__(self, source, downsample_factors=(1, 1)):
-        self.source = source
-        self.downsample_factors = downsample_factors
+    def __init__(self):
+        pass
 
     @classmethod
-    def from_file(cls, fn, source, downsample_factors=(1, 1)):
-        dffc = cls(source, downsample_factors)
+    def from_file(cls, fn, downsample_factors=(1, 1)):
+        dffc = cls()
         dffc.read_constants(fn)
+        dffc.set_downsample_factors(*downsample_factors)
+        return dffc
+
+    @classmethod
+    def from_constants(cls, dark, flat, components, downsample_factors=(1, 1)):
+        dffc = cls()
+        dffc.set_constants(dark, flat, components)
         dffc.set_downsample_factors(*downsample_factors)
         return dffc
 

--- a/src/dffc/correction.py
+++ b/src/dffc/correction.py
@@ -14,9 +14,9 @@ class DynamicFlatFieldCorrectionBase:
         pass
 
     @classmethod
-    def from_file(cls, fn, downsample_factors=(1, 1)):
+    def from_file(cls, fn, camera_name, downsample_factors=(1, 1)):
         dffc = cls()
-        dffc.read_constants(fn)
+        dffc.read_constants(fn, camera_name)
         dffc.set_downsample_factors(*downsample_factors)
         return dffc
 
@@ -27,8 +27,7 @@ class DynamicFlatFieldCorrectionBase:
         dffc.set_downsample_factors(*downsample_factors)
         return dffc
 
-    def read_constants(self, fn):
-        camera_name = self.source.partition('/')[0]
+    def read_constants(self, fn, camera_name):
         with h5py.File(fn, 'r') as f:
             g = f[camera_name]
             dark = g['mean_dark'][:]

--- a/src/dffc/correction.py
+++ b/src/dffc/correction.py
@@ -90,7 +90,7 @@ class DynamicFlatFieldCorrectionBase:
         image0 = self.downsample_scale_and_shift(image)
         r = fmin_l_bfgs_b(self.totalvar, w0, args=(image0,),
                           fprime=self.grad_totalvar,
-                          factr=fctr, iprint=0, pgtol=pgtol, maxls=100)
+                          factr=fctr, iprint=-1, pgtol=pgtol, maxls=100)
 
         return r[0], r[2]['warnflag']
 


### PR DESCRIPTION
This add constructors and members that help to redefine constructors for `ParallelProcessor` friends.

1. Add constructor from calibration constant arrays for `DynamicFlatFieldCorrectionBase`
2. Remove irrelevant parameters from `DynamicFlatFieldCorrectionBase.__ini__()` 
3. Add members in `ParallelProcessor` that return parameter-free constructor for `Reader` and `NumberCruncher`. It allows to use implementation of these classes with different signature of constructors.
4. Add `source`, `image_key` parameters for `FlatFieldCorrectionFileProcessor` and `FlatFieldCorrectionFileReader`.

cc @sarlotabirnsteinova 