### PR TITLE
Exit condition

### DIFF
--- a/src/dffc/__init__.py
+++ b/src/dffc/__init__.py
@@ -1,3 +1,4 @@
+# flake8: noqa F401
 from .constants import write_constants, process_flat, process_dark
 from .correction import (
     DynamicFlatFieldCorrectionBase, DynamicFlatFieldCorrectionNumba,

--- a/src/dffc/offline.py
+++ b/src/dffc/offline.py
@@ -12,6 +12,9 @@ class FlatFieldCorrectionFileReader(ReaderBase):
         self.image_key = image_key
         _, self.ny, self.nx = self.images.shape
 
+    def is_eof(self, nimg):
+        return nimg == 0 and self.nimg_wr[0] >= self.nimg_rd[0]
+
     def read(self):
         count = 0
         while count == 0:
@@ -62,7 +65,7 @@ class FlatFieldCorrectionFileReader(ReaderBase):
         self.trains.append(tid)
 
     def run(self, dc):
-        cam_data = dc.select([(self.source, "data.image.pixels")])
+        cam_data = dc.select([(self.source, self.image_key)])
         self.data_iter = iter(cam_data.trains())
 
         self.data_chunk = None

--- a/src/dffc/parallel/__init__.py
+++ b/src/dffc/parallel/__init__.py
@@ -1,2 +1,3 @@
+# flake8: noqa F401
 from .shmem import SharedMemory
 from .mpfarm import ReaderBase, NumberCruncherBase, ParallelProcessor

--- a/src/dffc/parallel/mpfarm.py
+++ b/src/dffc/parallel/mpfarm.py
@@ -13,6 +13,9 @@ class ReaderBase:
                          '_ctrl_neof', '_ctrl_started']
         shm.map_arrays(self, worker_arrays)
 
+    def is_eof(self, nimg):
+        return True
+
     def read(self):
         pass
 
@@ -65,7 +68,7 @@ class ReaderBase:
                 nimg_wr += nimg_corr
                 self.nimg_wr[0] = nimg_wr
 
-            if nimg == 0 and nimg_wr >= nimg_rd:
+            if self.is_eof(nimg):
                 break
 
             time.sleep(0)

--- a/src/dffc/totalvar_numba.py
+++ b/src/dffc/totalvar_numba.py
@@ -21,7 +21,7 @@ def totalvar_numba(w, image, flat0, flat0_mean, comp, comp_mean, vy):
     for k in range(nc):
         factor += nb.float32(w[k]) * comp_mean[k]
 
-    I = 0.0
+    I = 0.0  # noqa: E741
     for y in range(ny):
         for x in range(nx):
             flat_dyn = flat0[y, x]
@@ -35,7 +35,7 @@ def totalvar_numba(w, image, flat0, flat0_mean, comp, comp_mean, vy):
             vx = v
             vy[x] = v
 
-            I += math.sqrt(dx * dx + dy * dy)
+            I += math.sqrt(dx * dx + dy * dy)  # noqa: E741
 
     return I
 


### PR DESCRIPTION
This adds abstract method in ReaderBase that indicates the end of data stream. The method should be defined in the implementation. This allows to use custom exit-conditions specific to the implementation.