### PR TITLE
Fix plot_images with < 5 images

### DIFF
--- a/src/dynflatfield/draw.py
+++ b/src/dynflatfield/draw.py
@@ -8,7 +8,7 @@ def plot_images(images, figsize=None, nrow=4):
 
     if figsize is None:
         figsize = (16, 10)
-    fig, axs = plt.subplots(ncol, nrow, figsize=figsize)
+    fig, axs = plt.subplots(ncol, nrow, figsize=figsize, squeeze=False)
 
     for k in range(nimage):
         ax = axs[k // nrow, k % nrow]


### PR DESCRIPTION
We saw errors like this:

```
<ipython-input-6-a776044700db> in <module>
     14 
     15         display(Markdown("### The first corrected images in the trains (up to 20)"))
---> 16         plot_images(corrected_images, figsize=(13, 8))
     17         plt.show()
     18 

.../site-packages/dynflatfield/draw.py in plot_images(images, figsize, nrow)
     12 
     13     for k in range(nimage):
---> 14         ax = axs[k // nrow, k % nrow]
     15         im = ax.matshow(images[k])
     16         ax.axis(False)

IndexError: too many indices for array: array is 1-dimensional, but 2 were indexed
```

The code is assuming that the axes returned from `plt.subplots()` are a 2D array. But by default, if either `nrows` or `ncols` is 1, matplotlib drops the corresponding dimension. So with 4 images or fewer, you get a 1D array, and with 1 image you get a single `Axes` object. Setting `squeeze=False` always gives us a 2D array, even if its shape is `(1, 1)` ([`subplots()` docs](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.subplots.html)).